### PR TITLE
Limit user projects to their projects only

### DIFF
--- a/app/views/admin/info.html.erb
+++ b/app/views/admin/info.html.erb
@@ -1,6 +1,6 @@
 <h2><%=l(:label_information_plural)%></h2>
 
-<p><strong><%= Redmine::Info.versioned_name %>; OSB v1.237 </strong></p>
+<p><strong><%= Redmine::Info.versioned_name %>; OSB v1.238 </strong></p>
 
 <table class="list">
 <% @checklist.each do |label, result| %>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -137,16 +137,10 @@
 								</td> 	
 							</tr>
 						</thead>
-						<% if User.current.projects.any? || @projects.any? %>
-						    <%= call_hook(:view_welcome_index_left, :projects => @projects) %>
-                                                    <% for project in @projects %>
-							<tr><td colspan="2"><icon class="icon-list-alt"></icon><%= link_to_project(project) %></td></tr>
-						    <% end %>
-						    <% unless User.current.projects.empty? %>
+						<% if User.current.projects.any? %>
 							<% for project in User.current.projects %>
 							    <tr><td colspan="2"><icon class="icon-list-alt"></icon><%= link_to_project(project) %></td></tr>
 							<% end %>
-						    <% end %>
 						<% end %>
 					</table>
 					


### PR DESCRIPTION
By default, it shows the projects visible to the user first, and then
adds the user's projects. We want to limit the list to the user's
projects only.

Fixes https://github.com/OpenSourceBrain/geppetto-osb/issues/339